### PR TITLE
Introduce WS ioB delObj node and update related documentation

### DIFF
--- a/.github/workflows/update-beta-badge.yml
+++ b/.github/workflows/update-beta-badge.yml
@@ -40,13 +40,16 @@ jobs:
 
       - name: Commit and push badge update
         run: |
-          if git diff --quiet .github/badges/beta.json; then
-            echo "No badge changes detected"
-            exit 0
-          fi
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
+          # Re-generate badge on the correct branch to avoid conflicts
+          node .github/scripts/generate-beta-badge.mjs
+          if git diff --quiet .github/badges/beta.json; then
+            echo "No badge changes after re-check on main"
+            exit 0
+          fi
           git add .github/badges/beta.json
           git commit -m "chore: update beta badge"
-          git push
+          git push origin main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.4.0] - 2026-xx-xx
+
+### **Added**
+- New **WS ioB delObj** node for deleting ioBroker objects via WebSocket
+  - Supports single and recursive deletion (`msg.recursive`)
+  - Supports maintenance mode for non-standard/invalid IDs (`msg.maintenance`)
+
+### **Fixed**
+- `iob-in`: tombstone/delete events (null state) during recursive object deletion are now handled as debug messages instead of warnings
+
 ## [1.3.6] - 2026-05-09
 
 ### **Added**

--- a/docs/nodes/iob-delobject.md
+++ b/docs/nodes/iob-delobject.md
@@ -1,0 +1,84 @@
+# WS ioB delObj - Delete ioBroker Objects
+
+Delete ioBroker objects via WebSocket.
+
+## Purpose
+
+The WS ioB delObj node deletes existing ioBroker objects. It is intended for explicit cleanup tasks such as removing objects in custom namespaces or deleting generated object trees.
+
+## When to Use This Node
+
+- Delete obsolete custom objects in namespaces such as `0_userdata.0`
+- Remove generated test objects after development
+- Clean up whole object trees when recursive deletion is intended
+
+## Important Warning
+
+Deleting an object removes the ioBroker object definition. For states this is not the same as clearing the current value.
+
+- Use this node only for deliberate cleanup
+- Avoid deleting system objects unless you know the consequences
+- Recursive deletion can remove complete object hierarchies
+
+## Configuration
+
+### Basic Settings
+
+**Object ID**
+- The object identifier to delete
+- Leave empty to use `msg.objectId`
+
+**Delete children recursively**
+- Uses recursive object deletion for the selected object and all children below it
+
+**Maintenance mode**
+- Passes the maintenance flag through to ioBroker for special deletion scenarios when supported
+
+## Input Message
+
+### msg.objectId (string, optional)
+Overrides the configured object ID.
+
+### msg.recursive (boolean, optional)
+Overrides the recursive delete setting.
+
+### msg.maintenance (boolean, optional)
+Overrides the maintenance setting. When enabled, the backend may permit deletion of invalid or non-standard IDs that would otherwise be blocked by validation.
+
+## Output Message
+
+```javascript
+{
+  payload: {
+    success: true,
+    objectId: "0_userdata.0.cleanup.demo",
+    recursive: false,
+    maintenance: false
+  },
+  objectId: "0_userdata.0.cleanup.demo",
+  recursive: false,
+  maintenance: false,
+  timestamp: 1234567890
+}
+```
+
+## Example
+
+```javascript
+msg.objectId = "0_userdata.0.cleanup.demo";
+return msg;
+```
+
+For recursive deletion:
+
+```javascript
+msg.objectId = "0_userdata.0.cleanup";
+msg.recursive = true;
+return msg;
+```
+
+## Notes
+
+- This node deletes objects, not just state values
+- Current subscriptions to deleted objects will naturally stop receiving updates
+- Permissions must allow object deletion on the ioBroker side

--- a/examples/iob-delobject.json
+++ b/examples/iob-delobject.json
@@ -1,0 +1,143 @@
+[
+  {
+    "id": "example_delobject_flow",
+    "type": "tab",
+    "label": "iob-delobject Examples",
+    "disabled": false,
+    "info": "Demonstrates deleting single objects and recursive object trees."
+  },
+  {
+    "id": "inject_delete_single",
+    "type": "inject",
+    "z": "example_delobject_flow",
+    "name": "Delete Single Object",
+    "props": [
+      {
+        "p": "objectId",
+        "v": "0_userdata.0.cleanup.demo",
+        "vt": "str"
+      }
+    ],
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "onceDelay": 0.1,
+    "topic": "",
+    "x": 150,
+    "y": 100,
+    "wires": [
+      [
+        "delobject_single"
+      ]
+    ]
+  },
+  {
+    "id": "delobject_single",
+    "type": "iobdelobject",
+    "z": "example_delobject_flow",
+    "name": "Delete Single Object",
+    "objectId": "",
+    "recursive": false,
+    "maintenance": false,
+    "server": "iob_server",
+    "x": 400,
+    "y": 100,
+    "wires": [
+      [
+        "debug_delobject_single"
+      ]
+    ]
+  },
+  {
+    "id": "debug_delobject_single",
+    "type": "debug",
+    "z": "example_delobject_flow",
+    "name": "Delete Result",
+    "active": true,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "true",
+    "targetType": "full",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 650,
+    "y": 100,
+    "wires": []
+  },
+  {
+    "id": "inject_delete_recursive",
+    "type": "inject",
+    "z": "example_delobject_flow",
+    "name": "Delete Object Tree",
+    "props": [
+      {
+        "p": "objectId",
+        "v": "0_userdata.0.cleanup",
+        "vt": "str"
+      },
+      {
+        "p": "recursive",
+        "v": "true",
+        "vt": "bool"
+      }
+    ],
+    "repeat": "",
+    "crontab": "",
+    "once": false,
+    "onceDelay": 0.1,
+    "topic": "",
+    "x": 150,
+    "y": 180,
+    "wires": [
+      [
+        "delobject_recursive"
+      ]
+    ]
+  },
+  {
+    "id": "delobject_recursive",
+    "type": "iobdelobject",
+    "z": "example_delobject_flow",
+    "name": "Delete Tree",
+    "objectId": "",
+    "recursive": true,
+    "maintenance": false,
+    "server": "iob_server",
+    "x": 400,
+    "y": 180,
+    "wires": [
+      [
+        "debug_delobject_recursive"
+      ]
+    ]
+  },
+  {
+    "id": "debug_delobject_recursive",
+    "type": "debug",
+    "z": "example_delobject_flow",
+    "name": "Recursive Delete Result",
+    "active": true,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "true",
+    "targetType": "full",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 670,
+    "y": 180,
+    "wires": []
+  },
+  {
+    "id": "iob_server",
+    "type": "iob-config",
+    "name": "ioBroker Server",
+    "iobhost": "127.0.0.1",
+    "iobport": "8091",
+    "user": "",
+    "password": "",
+    "usessl": false,
+    "isdefault": false
+  }
+]

--- a/nodes/icons/iobroker_delobject.svg
+++ b/nodes/icons/iobroker_delobject.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="Layer_2"
+   x="0px"
+   y="0px"
+   width="648.5px"
+   height="652.8px"
+   viewBox="0 0 648.5 652.8"
+   style="enable-background:new 0 0 648.5 652.8;"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg">
+<style
+   type="text/css"
+   id="style1">
+   .st0{fill:#164477;}
+   .st1{fill:#3399CC;}
+   .st2{fill:#d64545;}
+   .st3{fill:#ffffff;}
+   .st4{fill:none;stroke:#d64545;stroke-width:10;stroke-linecap:round;}
+</style>
+
+<g id="g4">
+   <g id="g1">
+      <path
+   class="st0"
+   d="m 386,91 v 68.6 c 68.2,25.1 117,90.5 117,167 0,98.1 -80.2,177.9 -178.7,177.9 -98.5,0 -178.7,-79.8 -178.7,-177.9 0,-76.5 48.8,-141.9 117,-167 V 91 C 159.2,118.5 8.0147517,473.20662 8.0147517,586.20662 8.0147517,720.80662 191,570.2 324.2,570.2 c 133.2,0 315.30189,148.83991 315.30189,14.23991 C 639.50189,496.17387 489.2,118.5 386,91 Z"
+   id="path1" />
+   </g>
+   <path
+   class="st1"
+   d="M324.2,148.6c12.4,0,24.5,1.3,36.3,3.7V85.6c-11.8-1.8-23.9-2.7-36.3-2.7s-24.4,0.9-36.3,2.7v66.7   C299.7,149.9,311.8,148.6,324.2,148.6z"
+   id="path2" />
+   <g
+   id="g3">
+      <path
+   class="st1"
+   d="M324.2,175.3c-12.5,0-24.6,1.5-36.2,4.4v291c11.6,2.9,23.8,4.4,36.2,4.4c12.5,0,24.6-1.5,36.3-4.4v-291    C348.9,176.9,336.7,175.3,324.2,175.3z"
+   id="path3" />
+   </g>
+</g>
+
+<g transform="translate(500,488)">
+   <circle cx="0" cy="0" r="104" class="st2" />
+   <g transform="translate(0,8) scale(4.10)">
+      <rect x="-30" y="-44" width="60" height="12" rx="4" ry="4" class="st3" />
+      <rect x="-14" y="-54" width="28" height="8" rx="3" ry="3" class="st3" />
+      <rect x="-24" y="-30" width="48" height="56" rx="6" ry="6" class="st3" />
+      <line x1="-10" y1="-18" x2="-10" y2="16" class="st4" />
+      <line x1="0" y1="-18" x2="0" y2="16" class="st4" />
+      <line x1="10" y1="-18" x2="10" y2="16" class="st4" />
+   </g>
+</g>
+
+</svg>

--- a/nodes/iob-delobject.html
+++ b/nodes/iob-delobject.html
@@ -1,0 +1,139 @@
+<script type="text/javascript">
+    function loadSharedTreeView() {
+        return new Promise((resolve, reject) => {
+            if (window.ioBrokerSharedTreeView && window.ioBrokerSharedTreeView.initialized) {
+                resolve();
+                return;
+            }
+
+            const script = document.createElement('script');
+            script.src = 'iobroker/shared/iobroker-treeview.js?v=1.3.0';
+            script.async = true;
+
+            script.onload = () => {
+                if (window.ioBrokerSharedTreeView && window.ioBrokerSharedTreeView.initialized) {
+                    resolve();
+                } else {
+                    reject(new Error('TreeView component failed to initialize'));
+                }
+            };
+
+            script.onerror = () => reject(new Error('TreeView component script not found'));
+            document.head.appendChild(script);
+        });
+    }
+
+    RED.nodes.registerType('iobdelobject', {
+        category: 'ioBroker WS',
+        color: '#a6bbcf',
+        defaults: {
+            name: { value: '' },
+            objectId: { value: '' },
+            recursive: { value: false },
+            maintenance: { value: false },
+            server: { value: '', type: 'iob-config' }
+        },
+        inputs: 1,
+        outputs: 1,
+        icon: 'iobroker_delobject.svg',
+        paletteLabel: 'WS ioB delObj',
+        label: function() {
+            if (this.name) return this.name;
+            let label = this.objectId || 'iob-delobject';
+            if (this.recursive) {
+                label += ' (recursive)';
+            }
+            return label;
+        },
+
+        oneditprepare: function() {
+            const serverInput = $('#node-input-server');
+            window.ioBrokerEditorUtils.autoSelectSingleServerConfig(RED, this, serverInput);
+
+            loadSharedTreeView().then(() => {
+                this.treeController = window.ioBrokerSharedTreeView.setup({
+                    nodeType: 'iobdelobject',
+                    inputId: 'node-input-objectId',
+                    serverInputId: 'node-input-server',
+                    searchPlaceholder: 'Search objects to delete...',
+                    itemType: 'all',
+                    dataEndpoint: '/iobroker/ws/objects',
+                    enableWildcardDetection: false,
+                    wildcardInputId: null
+                });
+            }).catch(error => {
+                console.error('Failed to load TreeView component:', error);
+            });
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="iobdelobject">
+    <div style="margin-bottom: 15px; padding: 12px; background-color: #c62828; color: white; border: 2px solid #8e0000; border-radius: 4px; font-weight: bold;">
+        <i class="fa fa-exclamation-triangle" style="font-size: 20px; margin-right: 8px;"></i>
+        <span style="font-size: 14px;">WARNING: This node deletes ioBroker objects permanently.</span>
+        <div style="margin-top: 8px; font-size: 12px; font-weight: normal;">
+            Use it only for deliberate cleanup. Recursive deletion can remove whole object trees.
+        </div>
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-objectId"><i class="fa fa-dot-circle-o"></i> Object ID</label>
+        <input type="text" id="node-input-objectId" placeholder="Leave empty to use msg.objectId">
+    </div>
+
+    <div class="form-row">
+        <label>&nbsp;</label>
+        <input type="checkbox" id="node-input-recursive" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-recursive" style="width: auto; margin-left: 5px;">Delete children recursively</label>
+    </div>
+
+    <div class="form-row">
+        <label>&nbsp;</label>
+        <input type="checkbox" id="node-input-maintenance" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-maintenance" style="width: auto; margin-left: 5px;">Maintenance mode</label>
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-server"><i class="fa fa-server"></i> Server</label>
+        <input type="text" id="node-input-server">
+    </div>
+</script>
+
+<script type="text/html" data-help-name="iobdelobject">
+    <p>Delete ioBroker objects via WebSocket using <code>delObject</code> or <code>delObjects</code>.</p>
+
+    <h3>Configuration</h3>
+    <ul>
+        <li><b>Object ID:</b> Object ID to delete. Can be overridden by <code>msg.objectId</code>.</li>
+        <li><b>Delete children recursively:</b> Deletes the selected object and all child objects below it.</li>
+        <li><b>Maintenance mode:</b> Passes the maintenance flag to the backend.</li>
+        <li><b>Server:</b> The ioBroker server configuration.</li>
+    </ul>
+
+    <h3>Input</h3>
+    <ul>
+        <li><code>msg.objectId</code>: optional object ID override</li>
+        <li><code>msg.recursive</code>: optional boolean override for recursive deletion</li>
+        <li><code>msg.maintenance</code>: optional boolean override for maintenance mode. When <code>true</code>, the backend may allow deletion of invalid or non-standard IDs that would normally be rejected by validation.</li>
+    </ul>
+
+    <h3>Output</h3>
+    <p>On success the node emits a message with deletion metadata:</p>
+    <pre>{
+  payload: {
+    success: true,
+    objectId: '0_userdata.0.test',
+    recursive: false,
+    maintenance: false
+  }
+}</pre>
+
+    <h3>Warning</h3>
+    <p>Deleting an object also removes its definition from ioBroker. For state objects this is more than clearing a value.</p>
+</script>

--- a/nodes/iob-delobject.js
+++ b/nodes/iob-delobject.js
@@ -1,0 +1,93 @@
+const connectionManager = require('../lib/manager/websocket-manager');
+const { NodeHelpers } = require('../lib/utils/node-helpers');
+
+module.exports = function(RED) {
+    function iobdelobject(config) {
+        RED.nodes.createNode(this, config);
+        const node = this;
+
+        const { setStatus, setError } = NodeHelpers.createStatusHelpers(node);
+
+        const serverConfig = NodeHelpers.validateServerConfig(RED, config, setError);
+        if (!serverConfig) return;
+
+        const { globalConfig, connectionDetails, serverId } = serverConfig;
+
+        const settings = {
+            objectId: config.objectId?.trim() || '',
+            recursive: config.recursive === true,
+            maintenance: config.maintenance === true,
+            serverId,
+            nodeId: node.id
+        };
+
+        node.currentConfig = connectionDetails;
+        node.isInitialized = false;
+
+        const statusTexts = {
+            ready: settings.recursive ? 'Ready (recursive)' : 'Ready',
+            reconnected: settings.recursive ? 'Reconnected (recursive)' : 'Reconnected'
+        };
+
+        NodeHelpers.initializeConnection(
+            node, config, RED, settings, globalConfig, setStatus, statusTexts
+        );
+
+        node.on('input', async function(msg, send, done) {
+            try {
+                if (NodeHelpers.handleStatusRequest(msg, send, done, settings)) {
+                    return;
+                }
+
+                const objectId = (msg.objectId || settings.objectId || '').trim();
+                const recursive = typeof msg.recursive === 'boolean' ? msg.recursive : settings.recursive;
+                const maintenance = typeof msg.maintenance === 'boolean' ? msg.maintenance : settings.maintenance;
+
+                if (!objectId) {
+                    setStatus('red', 'ring', 'Object ID missing');
+                    const error = new Error('Object ID missing (configure Object ID or provide msg.objectId)');
+                    done && done(error);
+                    return;
+                }
+
+                setStatus('blue', 'dot', `Deleting ${objectId}...`);
+
+                if (recursive) {
+                    await connectionManager.delObjects(settings.serverId, objectId, maintenance);
+                } else {
+                    await connectionManager.delObject(settings.serverId, objectId, maintenance);
+                }
+
+                setStatus('green', 'dot', statusTexts.ready);
+
+                send({
+                    payload: {
+                        success: true,
+                        objectId,
+                        recursive,
+                        maintenance
+                    },
+                    objectId,
+                    recursive,
+                    maintenance,
+                    timestamp: Date.now()
+                });
+
+                done && done();
+            } catch (error) {
+                setStatus('red', 'ring', 'Delete failed');
+                node.error(`Failed to delete object: ${error.message}`);
+                done && done(error);
+            }
+        });
+
+        node.on('close', async function(removed, done) {
+            await NodeHelpers.handleNodeClose(node, settings, 'DelObject');
+            done();
+        });
+
+        node.on('error', NodeHelpers.createErrorHandler(node, setError));
+    }
+
+    RED.nodes.registerType('iobdelobject', iobdelobject);
+};

--- a/nodes/iob-in.js
+++ b/nodes/iob-in.js
@@ -411,8 +411,26 @@ module.exports = function (RED) {
 
         function onStateChange(stateId, state, isInitialValue = false) {
             try {
-                if (!state || state.val === undefined) {
-                    node.warn(`Invalid state data received for ${stateId}`);
+                if (state === null || state === undefined) {
+                    node.currentStateValues.delete(stateId);
+                    node.previous.delete(stateId);
+                    if (isSingleState && stateId === subscriptionPattern) {
+                        node.lastValue = undefined;
+                        node.hasReceivedValue = false;
+                    }
+                    node.debug(`State deleted/invalidated for ${stateId}`);
+                    return;
+                }
+
+                if (typeof state !== 'object' || Array.isArray(state)) {
+                    node.warn(`Invalid state payload type received for ${stateId}`);
+                    return;
+                }
+
+                if (state.val === undefined) {
+                    node.currentStateValues.delete(stateId);
+                    node.previous.delete(stateId);
+                    node.debug(`State without value ignored for ${stateId}`);
                     return;
                 }
 
@@ -494,6 +512,10 @@ module.exports = function (RED) {
 
             callback.onInitialValue = function (stateId, state) {
                 try {
+                    if (!state || typeof state !== 'object' || state.val === undefined) {
+                        return;
+                    }
+
                     if (!shouldSendMessage(state.ack, settings.ackFilter)) {
                         return;
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-iobroker",
-  "version": "1.3.6",
+  "version": "1.4.0-beta.1",
   "description": "Node-RED nodes for ioBroker integration via WebSocket. Provides input, output, get, object management, historical data access, and live log monitoring capabilities.",
   "keywords": [
     "node-red",


### PR DESCRIPTION
This pull request introduces a new node for deleting ioBroker objects via WebSocket, improves documentation and examples, and fixes how deleted/tombstoned states are handled in the input node. It also contains workflow and metadata updates.

**New Feature: Object Deletion Node**
- Added a new node `iobdelobject` for deleting ioBroker objects (including recursive deletion and maintenance mode), with full editor UI, help, and backend logic. [[1]](diffhunk://#diff-ab83d505bbbcbdd7390e64d1978aed61d0f084efc16d93e063ceaee88db92270R1-R93) [[2]](diffhunk://#diff-db9603180bf5b7750fd021ddf67584a4f6a790d516a80b62ffabc631481b44feR1-R139)
- Added comprehensive documentation for the new node in `docs/nodes/iob-delobject.md`.
- Provided example flows for single and recursive object deletion in `examples/iob-delobject.json`.

**Bug Fixes & Improvements: Input Node Handling**
- Improved `iob-in` node to treat tombstone/delete events (null state) during recursive object deletion as debug messages instead of warnings, and to ignore invalid state payloads more robustly. [[1]](diffhunk://#diff-4b1235dec57a1d421425af58058c96fc7c4e044887adaf7aea8ae2b941aa9f0fL414-R433) [[2]](diffhunk://#diff-4b1235dec57a1d421425af58058c96fc7c4e044887adaf7aea8ae2b941aa9f0fR515-R518)

**Documentation & Metadata**
- Updated `CHANGELOG.md` for v1.4.0 with details on the new node and bug fixes.
- Updated `package.json` version to `1.4.0-beta.1`.

**Workflow**
- Improved the badge update GitHub workflow to ensure badge generation and pushing always happens on the correct branch, reducing conflicts.